### PR TITLE
Fix error in URL

### DIFF
--- a/frontend/src/components/googlemaps/map.jsx
+++ b/frontend/src/components/googlemaps/map.jsx
@@ -115,7 +115,7 @@ class MapShow extends React.Component {
                 <div className='map-container'>
                     <div className='map-title'>Nearby Stores</div>
                     <Map
-                        googleMapURL={`https://maps.googleapis.com/maps/api/js?key=AIzaSyDWRrh9zLyd_Xu6eMqomtLpTDFNX-O_y4A&libraries=geometry,drawing,places`}
+                        googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE}&libraries=geometry,drawing,places`}
                         loadingElement={<div style={{ height: `100%` }} />}
                         containerElement={<div style={{ height: `400px` }} />}
                         mapElement={<div style={{ height: `100%` }} />}


### PR DESCRIPTION
This line of code had our old value hard-coded in a different place, so part of the Map function used our old code, while the other part used the new one. Now they both use the same one. 